### PR TITLE
fix: lanczos throwing when destination dimensions are not round

### DIFF
--- a/.changeset/lemon-penguins-bathe.md
+++ b/.changeset/lemon-penguins-bathe.md
@@ -1,0 +1,5 @@
+---
+'@masknet/stego-js': patch
+---
+
+fix: lanczos throwing when destination dimensions are not round

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -15,7 +15,7 @@ export function preprocessImage(
   if (imageData.width <= MAX_WIDTH && imageData.height <= MAX_WIDTH) return imageData
   const scale = MAX_WIDTH / Math.max(imageData.width, imageData.height)
   const [w, h] = [imageData.width * scale, imageData.height * scale]
-  const scaled = getScaled(w, h)
+  const scaled = getScaled(Math.round(w), Math.round(h))
   if (scaled) {
     lanczos(imageData, scaled)
     return scaled

--- a/tests/image.ts
+++ b/tests/image.ts
@@ -1,0 +1,23 @@
+import { expect, test, vi } from 'vitest'
+import { preprocessImage } from '../src/utils/image.js'
+import { MAX_WIDTH } from '../src/constant.js'
+
+test('preprocessImage rounds the dimensions of the scaled image', async () => {
+  const getScaled = vi.fn().mockImplementation((width, height) => ({
+    height,
+    width,
+    colorSpace: 'srgb',
+    data: new Uint8ClampedArray(width * height * 4),
+  }))
+  preprocessImage(
+    {
+      width: 1980,
+      height: 1024,
+      colorSpace: 'srgb',
+      data: new Uint8ClampedArray(1980 * 1024 * 4),
+    },
+    getScaled,
+  )
+
+  expect(getScaled).toHaveBeenCalledWith(MAX_WIDTH, 1014)
+})


### PR DESCRIPTION
Thanks for releasing the project! It's helping me solve a tricky problem.

While using it with images over the `MAX_WIDTH` I encountered the following error

<img width="1155" alt="Screenshot 2024-11-21 at 16 07 33" src="https://github.com/user-attachments/assets/8fc9e109-8339-409c-934a-aceb4fd682f6">

Investigating it seems to be cause by the preprocessImage function not scaling to a rounded width and/or height causing lanczos to blow up with `RangeError: byte length of Uint32Array should be a multiple of 4`

This change ensures that the target dimensions are rounded and the resulting target `Uint32Array` has a length that is a multiple of 4

